### PR TITLE
Fix magnitude column in dataframe

### DIFF
--- a/R/alnDotPlot.R
+++ b/R/alnDotPlot.R
@@ -60,7 +60,7 @@ matrix_to_dataframe <- function(mat) {
   seq2 = rep(seq2, times = nrows)
 
   #magnitude
-  magnitude = c(mat)
+  magnitude = c(t(mat))
 
   #data frame
   data = data.frame(Seq1 = seq1, Seq2 = seq2, Magnitude = magnitude)


### PR DESCRIPTION
When converting a dot matrix into a dataframe in `matrix_to_dataframe` function, magnitude was added incorrectly. 
This fixes the issue by transposing magnitude.